### PR TITLE
Use dnf instead of yum module

### DIFF
--- a/roles/zammad/tasks/install.yml
+++ b/roles/zammad/tasks/install.yml
@@ -10,7 +10,7 @@
   block:
 
     - name: "Install | Install EPEL repo"
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: "epel-release"
         state: "present"
 


### PR DESCRIPTION
Fixes ansible-lint error:
> fqcn[action-core]: Use FQCN for builtin module actions (ansible.builtin.yum).
> roles/zammad/tasks/install.yml:12 Use `ansible.builtin.dnf` or `ansible.legacy.dnf` instead.