### PR TITLE
Add support for Ubuntu 24.04

### DIFF
--- a/.github/workflows/keepalived.yml
+++ b/.github/workflows/keepalived.yml
@@ -40,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - "ghcr.io/hifis-net/ubuntu-systemd:24.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:22.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:20.04"
 

--- a/.github/workflows/netplan.yml
+++ b/.github/workflows/netplan.yml
@@ -42,6 +42,7 @@ jobs:
         image:
           - "ghcr.io/hifis-net/ubuntu-systemd:20.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:22.04"
+          - "ghcr.io/hifis-net/ubuntu-systemd:24.04"
 
     steps:
       - name: "Check out the codebase."

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -45,6 +45,7 @@ jobs:
         image:
           - "ghcr.io/hifis-net/ubuntu-systemd:20.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:22.04"
+          - "ghcr.io/hifis-net/ubuntu-systemd:24.04"
 
     steps:
       - name: "Check out the codebase."

--- a/.github/workflows/ssh_keys.yml
+++ b/.github/workflows/ssh_keys.yml
@@ -46,6 +46,7 @@ jobs:
           - "ghcr.io/hifis-net/ubuntu-systemd:18.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:20.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:22.04"
+          - "ghcr.io/hifis-net/ubuntu-systemd:24.04"
           - "ghcr.io/hifis-net/debian-systemd:10"
           - "ghcr.io/hifis-net/debian-systemd:11"
 

--- a/.github/workflows/unattended_upgrades.yml
+++ b/.github/workflows/unattended_upgrades.yml
@@ -40,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - "ghcr.io/hifis-net/ubuntu-systemd:24.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:22.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:20.04"
           - "ghcr.io/hifis-net/debian-systemd:12"

--- a/molecule/keepalived/molecule.yml
+++ b/molecule/keepalived/molecule.yml
@@ -11,7 +11,7 @@ driver:
   name: "podman"
 platforms:
   - name: "instancekeepalived"
-    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:22.04}"
+    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
     pre_build_image: true
     privileged: true
     systemd: "always"

--- a/molecule/netplan/molecule.yml
+++ b/molecule/netplan/molecule.yml
@@ -10,7 +10,7 @@ driver:
   name: "podman"
 platforms:
   - name: "instancenetplan"
-    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:22.04}"
+    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
     pre_build_image: true
     override_command: false
     privileged: true

--- a/molecule/redis/molecule.yml
+++ b/molecule/redis/molecule.yml
@@ -10,7 +10,7 @@ driver:
   name: "podman"
 platforms:
   - name: "instance_redis"
-    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:22.04}"
+    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
     pre_build_image: true
     privileged: true
     systemd: "always"

--- a/molecule/ssh_keys/molecule.yml
+++ b/molecule/ssh_keys/molecule.yml
@@ -12,7 +12,7 @@ driver:
   name: "podman"
 platforms:
   - name: "instance"
-    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:22.04}"
+    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
     pre_build_image: true
     privileged: true
     override_command: false

--- a/molecule/unattended_upgrades/molecule.yml
+++ b/molecule/unattended_upgrades/molecule.yml
@@ -10,7 +10,7 @@ driver:
   name: "podman"
 platforms:
   - name: "instance"
-    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:22.04}"
+    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
     pre_build_image: true
     privileged: true
     override_command: false

--- a/roles/keepalived/meta/main.yml
+++ b/roles/keepalived/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
       versions:
         - "focal"
         - "jammy"
+        - "noble"
 
   galaxy_tags:
     - "keepalived"

--- a/roles/netplan/meta/main.yml
+++ b/roles/netplan/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
       versions:
         - "focal"
         - "jammy"
+        - "noble"
 
   galaxy_tags:
     - "netplan"

--- a/roles/redis/meta/main.yml
+++ b/roles/redis/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
       versions:
         - "focal"
         - "jammy"
+        - "noble"
 
   galaxy_tags:
     - "redis"

--- a/roles/ssh_keys/meta/main.yml
+++ b/roles/ssh_keys/meta/main.yml
@@ -26,6 +26,7 @@ galaxy_info:
         - "bionic"
         - "focal"
         - "jammy"
+        - "noble"
     - name: "Debian"
       versions:
         - "buster"

--- a/roles/unattended_upgrades/meta/main.yml
+++ b/roles/unattended_upgrades/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
       versions:
         - "jammy"
         - "focal"
+        - "noble"
     - name: "Debian"
       versions:
         - "buster"


### PR DESCRIPTION
Adds Ubuntu 24.04 support for roles
* keepalived
* netplan
* redis
* ssh_keys
* unattended_upgrades

(GitLab does not yet have support for 24.04 [see here](https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/8509). Only HAProxy PPA for 2.9 supports noble. Waiting for https://github.com/geerlingguy/ansible-role-postgresql/pull/258 to add support for zammad)

Related to #252 