### PR TITLE
Add parameter to use specified configuration file

### DIFF
--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -141,7 +141,7 @@
 - name: "Verify Keepalived configuration."
   become: true
   ansible.builtin.command:
-    cmd: "{{ keepalived_executable_path | quote }} --config-test {{ keepalived_conf_file_path | quote }}"
+    cmd: "{{ keepalived_executable_path | quote }} --config-test --use-file {{ keepalived_conf_file_path | quote }}"
   register: "config_check"
   changed_when: "config_check.rc != 0"
 

--- a/roles/keepalived/templates/keepalived.service.j2
+++ b/roles/keepalived/templates/keepalived.service.j2
@@ -15,7 +15,7 @@ RuntimeDirectory=keepalived
 PIDFile={{ keepalived_pid_file_path }}
 KillMode=process
 EnvironmentFile=-{{ keepalived_sysconfig_file_path }}
-ExecStart={{ keepalived_executable_path }} -p {{ keepalived_pid_file_path }} $KEEPALIVED_OPTIONS
+ExecStart={{ keepalived_executable_path }} -p {{ keepalived_pid_file_path }} --use-file {{ keepalived_conf_file_path }} $KEEPALIVED_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Without the --use-file parameter the command always uses the default keepalived.conf file location