### PR TITLE
Add custom routes

### DIFF
--- a/roles/netplan/templates/config.yaml.j2
+++ b/roles/netplan/templates/config.yaml.j2
@@ -22,6 +22,21 @@ network:
       routes:
         - to: "default"
           via: "{{ ethernet['gateway4'] }}"
+{% if ethernet['routes'] is defined %}
+{% for route in ethernet['routes']%}
+        - to: "{{ route.to }}"
+          via: "{{ route.via }}"
+{% endfor %}
+{% endif %}
+{% endif %}
+{% if ethernet['gateway4'] is not defined %}
+{% if ethernet['routes'] is defined %}
+      routes:
+{% for route in ethernet['routes']%}
+        - to: "{{ route.to }}"
+          via: "{{ route.via }}"
+{% endfor %}
+{% endif %}
 {% endif %}
 {% if ethernet['addresses'] is defined %}
       addresses:


### PR DESCRIPTION
Currently, the role only sets a default route. With this commit it is possible to add additional routes to the default route as well as no default route at all for secondary interfaces.