### PR TITLE
Bump keepalived from version 2.3.1 to 2.3.2

### DIFF
--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -61,7 +61,7 @@ keepalived_virtual_ipaddress_configs:
 Variable to pin the Keepalived version to a certain value:
 
 ```yaml
-keepalived_version: '2.3.1'
+keepalived_version: '2.3.2'
 ```
 
 #### List of dependencies of Keepalived

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -6,7 +6,7 @@
 ---
 
 # Keepalived version
-keepalived_version: "2.3.1"
+keepalived_version: "2.3.2"
 # URL from which Keepalived can be downloaded
 keepalived_download_url: "https://www.keepalived.org/software/keepalived-{{ keepalived_version }}.tar.gz"
 # List of dependencies of Keepalived


### PR DESCRIPTION
- [Release notes](https://www.keepalived.org/release-notes/Release-2.3.2.html)