### PR TITLE
role ssh_keys: ignores errors when in check-mode and users doesnt exist yet

### DIFF
--- a/molecule/ssh_keys/molecule.yml
+++ b/molecule/ssh_keys/molecule.yml
@@ -22,3 +22,18 @@ provisioner:
   name: "ansible"
 verifier:
   name: "ansible"
+scenario:
+  name: "ssh_keys"
+  test_sequence:
+    - "destroy"
+    - "dependency"
+    - "syntax"
+    - "create"
+    - "prepare"
+    - "check"
+    - "converge"
+    - "idempotence"
+    - "check"
+    - "side_effect"
+    - "verify"
+    - "destroy"

--- a/roles/ssh_keys/tasks/main.yml
+++ b/roles/ssh_keys/tasks/main.yml
@@ -27,5 +27,6 @@
   loop: "{{ ssh_user_list }}"
   loop_control:
     loop_var: "ssh_user"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 ...


### PR DESCRIPTION
The following problem is solved:

If users do not yet exist (but create_user_account: true is set), the execution of the task for managing the SSH keys in check mode fails. 
Without check mode, this would not be a problem, as the users are created one task beforehand.