### PR TITLE
Fix autoscaler URL template and install 0.28.0 by default

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,5 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+exclude_paths:
+  - ".cache/"
+  - ".ansible/"
 skip_list:
   - 'var-naming[no-role-prefix]'

--- a/roles/gitlab_runner/defaults/main.yml
+++ b/roles/gitlab_runner/defaults/main.yml
@@ -46,8 +46,9 @@ gitlab_runner_session_server_listen_address: "0.0.0.0:8093"
 gitlab_runner_session_server_advertise_address: "{{ gitlab_runner_session_server_listen_address }}"
 gitlab_runner_session_server_timeout: 1800
 
-gitlab_runner_autoscaler_plugin_version: "0.21.1"
-gitlab_runner_autoscaler_plugin_url: "https://github.com/sardinasystems/fleeting-plugin-openstack/releases/download/{{ gitlab_runner_autoscaler_plugin_version }}/fleeting-plugin-openstack_{{ gitlab_runner_autoscaler_plugin_version }}_linux_amd64.tar.gz"
-gitlab_runner_autoscaler_plugin_checksumfile: "https://github.com/sardinasystems/fleeting-plugin-openstack/releases/download/{{ gitlab_runner_autoscaler_plugin_version }}/fleeting-plugin-openstack_{{ gitlab_runner_autoscaler_plugin_version }}_sha512-checksums.txt"
+gitlab_runner_autoscaler_plugin_version: "v0.28.0"
+gitlab_runner_autoscaler_binary_version: "{{ gitlab_runner_autoscaler_plugin_version | replace('v', '') }}"
+gitlab_runner_autoscaler_plugin_url: "https://github.com/sardinasystems/fleeting-plugin-openstack/releases/download/{{ gitlab_runner_autoscaler_plugin_version }}/fleeting-plugin-openstack_{{ gitlab_runner_autoscaler_binary_version }}_linux_amd64.tar.gz"
+gitlab_runner_autoscaler_plugin_checksumfile: "https://github.com/sardinasystems/fleeting-plugin-openstack/releases/download/{{ gitlab_runner_autoscaler_plugin_version }}/fleeting-plugin-openstack_{{ gitlab_runner_autoscaler_binary_version }}_sha512-checksums.txt"
 
 gitlab_runner_butane_config_template: "butane-config.bu.j2"

--- a/roles/gitlab_runner/tasks/install.autoscaler-plugin.yml
+++ b/roles/gitlab_runner/tasks/install.autoscaler-plugin.yml
@@ -21,7 +21,7 @@
   check_mode: false
 
 - name: "Download and install fleeting plugin"
-  when: "not _fleeting_plugin_openstack_stat.stat.exists or _fleeting_plugin_version_installed.stdout != gitlab_runner_autoscaler_plugin_version"
+  when: "not _fleeting_plugin_openstack_stat.stat.exists or _fleeting_plugin_version_installed.stdout != gitlab_runner_autoscaler_binary_version"
   block:
     - name: "Create temporary directory"
       ansible.builtin.tempfile:


### PR DESCRIPTION
The fleeting-plugin-openstack project changed it's release naming scheme to include a leading `v`. The binary itself still makes use of the version without a leading `v` requiring us to update our role behavior.

The implementation should work for both versions using the previous naming scheme as well as the new one.