### PR TITLE
Fix failing GitLab KAS in molecule test

### DIFF
--- a/molecule/gitlab/molecule.yml
+++ b/molecule/gitlab/molecule.yml
@@ -36,6 +36,10 @@ provisioner:
               - key: "modify_kernel_parameters"
                 type: "plain"
                 value: "false"
+          - gitlab_kas:
+              - key: "env"
+                type: "plain"
+                value: "{ 'OWN_PRIVATE_API_URL' => 'grpc://127.0.0.1:8155' }"
         gitlab_feature_flags:
           # See https://docs.gitlab.com/ee/user/feature_flags.html
           - name: "vscode_web_ide"


### PR DESCRIPTION
In GitLab 17.8.0, GitLab agent server for Kubernetes (KAS) does not start with the default settings on the GitLab Linux package (Omnibus) and Docker installations.

* Closes #367 