### PR TITLE
Do not run search index rebuild by default

### DIFF
--- a/roles/zammad/README.md
+++ b/roles/zammad/README.md
@@ -124,6 +124,15 @@ elasticsearch_url: "http://localhost:9200"
 
 Elasticsearch server address.
 
+```yaml
+zammad_force_es_searchindex_rebuild: false
+```
+
+By default, the Elasticsearch indexes are only rebuilt during the initial
+installation.
+Set this variable to `true` to force Ansible to trigger the rebuild of the
+Zammad search index when Zammad is updated.
+
 ## Dependencies
 
 Zammad requires Elasticsearch and PostgreSQL database server.

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -15,5 +15,7 @@ zammad_ssl_key_path: "/etc/ssl/private/zammad_key.pem"
 zammad_nginx_additional_server_configs: []
 zammad_nginx_server_tokens: "off"
 
+zammad_force_es_searchindex_rebuild: false
+
 elasticsearch_url: "http://localhost:9200"
 ...

--- a/roles/zammad/handlers/main.yml
+++ b/roles/zammad/handlers/main.yml
@@ -17,5 +17,6 @@
 - name: "Build search index"
   ansible.builtin.command: "zammad run rake zammad:searchindex:rebuild"
   changed_when: true
+  when: "not __zammad_is_installed or zammad_force_es_searchindex_rebuild"
 
 ...

--- a/roles/zammad/tasks/install.yml
+++ b/roles/zammad/tasks/install.yml
@@ -43,6 +43,14 @@
         update_cache: true
         mode: "0644"
 
+- name: "Gather the package facts to check wether Zammad has already been installed"
+  ansible.builtin.package_facts:
+    manager: "auto"
+
+- name: "Check if Zammad is already installed"
+  ansible.builtin.set_fact:
+    __zammad_is_installed: "{{ 'zammad' in ansible_facts.packages }}"
+
 - name: "Install | Install Zammad package"
   ansible.builtin.package:
     name: "zammad={{ zammad_version }}*"


### PR DESCRIPTION
The search index rebuild is not required by default when updating Zammad. Since this is a time consuming operation it should not be executed unless explicitly required.