### PR TITLE
Rename elasticsearch_url variable

### DIFF
--- a/roles/zammad/README.md
+++ b/roles/zammad/README.md
@@ -119,7 +119,7 @@ configuring multiple domains or the redirection of outdated domains to the
 most recent one.
 
 ```yaml
-elasticsearch_url: "http://localhost:9200"
+zammad_elasticsearch_url: "http://localhost:9200"
 ```
 
 Elasticsearch server address.

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -17,5 +17,5 @@ zammad_nginx_server_tokens: "off"
 
 zammad_force_es_searchindex_rebuild: false
 
-elasticsearch_url: "http://localhost:9200"
+zammad_elasticsearch_url: "http://localhost:9200"
 ...

--- a/roles/zammad/handlers/main.yml
+++ b/roles/zammad/handlers/main.yml
@@ -11,7 +11,7 @@
 
 - name: "Set Elasticsearch server address"
   ansible.builtin.command: >-
-    zammad run rails r "Setting.set('es_url', '{{ elasticsearch_url | quote }}')"
+    zammad run rails r "Setting.set('es_url', '{{ zammad_elasticsearch_url | quote }}')"
   changed_when: true
 
 - name: "Build search index"

--- a/roles/zammad/tasks/install.yml
+++ b/roles/zammad/tasks/install.yml
@@ -5,6 +5,18 @@
 
 ---
 
+- name: "Variable elasticsearch_url is deprecated"
+  ansible.builtin.debug:
+    msg:
+      - "The variable elasticsearch_url is deprecated and will be removed in the next major release."
+      - "Please use zammad_elasticsearch_url instead"
+  when: "elasticsearch_url is defined and elasticsearch_url | length > 0"
+
+- name: "Set variable zammad_elasticsearch_url for backwards compatibility"
+  ansible.builtin.set_fact:
+    zammad_elasticsearch_url: "{{ elasticsearch_url }}"
+  when: "elasticsearch_url is defined and elasticsearch_url | length > 0"
+
 - name: "Configure Zammad repository for Centos-like"
   when: "ansible_distribution | lower == 'centos'"
   block:


### PR DESCRIPTION
The variable is not prefixed with the role name. In order to prevent name clashes it is renamed to zammad_elasticsearch_url.