### PR TITLE
Convert keepalived_notification_email to a list

### DIFF
--- a/molecule/keepalived/converge.yml
+++ b/molecule/keepalived/converge.yml
@@ -7,11 +7,6 @@
 
 - name: "Converge"
   hosts: "all"
-  vars:
-    keepalived_unicast_peers:
-      - "172.17.0.3"
-      - "172.17.0.4"
-    keepalived_virtual_ip_address: "172.17.0.20"
   tasks:
     - name: "Include keepalived role"
       ansible.builtin.include_role:

--- a/molecule/keepalived/molecule.yml
+++ b/molecule/keepalived/molecule.yml
@@ -35,9 +35,10 @@ provisioner:
             - "172.17.0.3"
             - "172.17.0.4"
           keepalived_virtual_ip_address: "172.17.0.20"
-          keepalived_notification_email:
-            - "root@localhost"
-            - "sysadmin@firewall.loc"
+          keepalived_notification_email: "sysadmin@firewall.loc"
+          # keepalived_notification_emails:
+          #   - "root@localhost"
+          #   - "sysadmin@firewall.loc"
 verifier:
   name: "ansible"
 scenario:

--- a/molecule/keepalived/molecule.yml
+++ b/molecule/keepalived/molecule.yml
@@ -27,6 +27,14 @@ provisioner:
     check: "converge.yml"
     converge: "converge.yml"
     verify: "verify.yml"
+  inventory:
+    hosts:
+      all:
+        vars:
+          keepalived_unicast_peers:
+            - "172.17.0.3"
+            - "172.17.0.4"
+          keepalived_virtual_ip_address: "172.17.0.20"
 verifier:
   name: "ansible"
 scenario:

--- a/molecule/keepalived/molecule.yml
+++ b/molecule/keepalived/molecule.yml
@@ -35,6 +35,9 @@ provisioner:
             - "172.17.0.3"
             - "172.17.0.4"
           keepalived_virtual_ip_address: "172.17.0.20"
+          keepalived_notification_email:
+            - "root@localhost"
+            - "sysadmin@firewall.loc"
 verifier:
   name: "ansible"
 scenario:

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -156,7 +156,7 @@ keepalived_pid_file_path: "/run/keepalived/keepalived.pid"
 List of email accounts that will receive notification mails:
 
 ```yaml
-keepalived_notification_email:
+keepalived_notification_emails:
   - 'root@localhost'
 ```
 

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -153,10 +153,11 @@ keepalived_pid_file_path: "/run/keepalived/keepalived.pid"
 
 #### Configure notification email address
 
-Configure recipient of notification emails:
+List of email accounts that will receive notification mails:
 
 ```yaml
-keepalived_notification_email: 'name@localhost'
+keepalived_notification_email:
+  - 'root@localhost'
 ```
 
 #### Configure notification sender

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -44,8 +44,8 @@ keepalived_service_file_path: "/etc/systemd/system/keepalived.service"
 keepalived_pid_file_path: "/run/keepalived/keepalived.pid"
 
 
-# Configure notification email address
-keepalived_notification_email: "name@localhost"
+# Configure email accounts that will receive notification mails
+keepalived_notification_email: ["root@localhost"]
 # Configure notification sender
 keepalived_notification_email_from: "keepalived@localhost"
 # Configure SMTP Server

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -45,7 +45,7 @@ keepalived_pid_file_path: "/run/keepalived/keepalived.pid"
 
 
 # Configure email accounts that will receive notification mails
-keepalived_notification_email: ["root@localhost"]
+keepalived_notification_emails: ["root@localhost"]
 # Configure notification sender
 keepalived_notification_email_from: "keepalived@localhost"
 # Configure SMTP Server

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -13,6 +13,20 @@
     fail_msg: "Some mandatory variables are not set."
     success_msg: "All mandatory variables are set."
 
+- name: "Variable keepalived_notification_email is deprecated"
+  when: "keepalived_notification_email | default('') | length > 0"
+  block:
+
+    - name: "Set keepalived_notification_emails variable"
+      ansible.builtin.set_fact:
+        keepalived_notification_emails: ["{{ keepalived_notification_email }}"]
+
+    - name: "Show deprecation warning"
+      ansible.builtin.debug:
+        msg:
+          - "The variable keepalived_notification_email is deprecated and will be removed in the next major release."
+          - "Please use list variable 'keepalived_notification_emails' instead."
+
 - name: "Install dependencies for Keepalived."
   become: true
   ansible.builtin.package:

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -11,9 +11,9 @@ global_defs {
 {% if keepalived_set_script_security_flag %}
     enable_script_security
 {% endif %}
-{% if keepalived_notification_email | default([]) | length > 0 %}
+{% if keepalived_notification_emails | default([]) | length > 0 %}
     notification_email {
-{% for email in keepalived_notification_email %}
+{% for email in keepalived_notification_emails %}
         {{ email }}
 {% endfor %}
     }

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -17,10 +17,10 @@ global_defs {
         {{ email }}
 {% endfor %}
     }
-{% endif %}
     notification_email_from {{ keepalived_notification_email_from }}
     smtp_server {{ keepalived_smtp_server }}
     smtp_connect_timeout 30
+{% endif %}
 {% if keepalived_router_id is defined %}
     router_id {{ keepalived_router_id }}
 {% endif %}

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -11,9 +11,13 @@ global_defs {
 {% if keepalived_set_script_security_flag %}
     enable_script_security
 {% endif %}
+{% if keepalived_notification_email | default([]) | length > 0 %}
     notification_email {
-        {{ keepalived_notification_email }}
+{% for email in keepalived_notification_email %}
+        {{ email }}
+{% endfor %}
     }
+{% endif %}
     notification_email_from {{ keepalived_notification_email_from }}
     smtp_server {{ keepalived_smtp_server }}
     smtp_connect_timeout 30


### PR DESCRIPTION
* Disable Keepalived's mail notification configuration when no notification email has been specified
* Convert `keepalived_notification_email` to a list with a more meaningful default value and rename it to `keepalived_notification_emails`