### PR TITLE
Fix molecule docker startup for Debian and Ubuntu 20.04

### DIFF
--- a/molecule/gitlab_runner/converge.yml
+++ b/molecule/gitlab_runner/converge.yml
@@ -7,6 +7,14 @@
 - name: "Converge"
   hosts: "all"
   tasks:
+    - name: "Set Docker daemon options for Ubuntu 20.04 and Debian"
+      ansible.builtin.set_fact:
+        docker_daemon_options:
+          ipv6: false
+          ip6tables: false
+      when: "(ansible_distribution == 'Ubuntu' and ansible_distribution_version == '20.04') or
+            ansible_distribution == 'Debian'"
+
     - name: "Include gitlab_runner role"
       ansible.builtin.include_role:
         name: "hifis.toolkit.gitlab_runner"


### PR DESCRIPTION
This change fixes an issue that appeared in the Molecule setup for Debian 11, 12 as well as Ubuntu 20.04 as shown in https://github.com/hifis-net/ansible-collection-toolkit/actions/runs/13511834630.

This seems to be related to a recent change in Docker 28.0.0