### PR TITLE
Replace git_data_dirs

### DIFF
--- a/molecule/gitlab/molecule.yml
+++ b/molecule/gitlab/molecule.yml
@@ -29,6 +29,8 @@ provisioner:
   inventory:
     host_vars:
       instancegitlab:
+        gitlab_version: "17.11.2"
+        gitlab_release: "ce.0"
         gitlab_edition: "gitlab-ce"
         gitlab_ip_range: "0.0.0.0/0"
         gitlab_additional_configurations:

--- a/molecule/gitlab/verify.yml
+++ b/molecule/gitlab/verify.yml
@@ -14,15 +14,22 @@
     - name: "Assert that GitLab Omnibus package is installed"
       ansible.builtin.assert:
         that:
-          - "'{{ gitlab_edition }}' in ansible_facts.packages"
+          - "gitlab_edition in ansible_facts.packages"
       when:
         - "gitlab_edition is defined"
+
+    - name: "Set expected package version of GitLab"
+      ansible.builtin.set_fact:
+        gitlab_expected_package_version: "{{ gitlab_version }}-{{ gitlab_release }}"
+      when:
+        - "gitlab_edition is defined"
+        - "gitlab_version is defined"
+        - "gitlab_release is defined"
 
     - name: "Assert that installed GitLab version is equal to the desired one"
       ansible.builtin.assert:
         that:
-          - "ansible_facts.packages['{{ gitlab_edition }}'][0].version == gitlab_version"
-          - "ansible_facts.packages['{{ gitlab_edition }}'][0].release == gitlab_release"
+          - "ansible_facts.packages[gitlab_edition][0].version == gitlab_expected_package_version"
       when:
         - "gitlab_edition is defined"
         - "gitlab_version is defined"

--- a/roles/gitlab/defaults/main.yml
+++ b/roles/gitlab/defaults/main.yml
@@ -93,4 +93,7 @@ gitlab_mattermost_only_context: "false"
 
 gitlab_feature_flags: []
 
+# Internal variable to determine whether the configuration object for Gitaly
+# is already present in gitlab_additional_configurations
+__gitaly_configuration_exists: false
 ...

--- a/roles/gitlab/tasks/configure.yml
+++ b/roles/gitlab/tasks/configure.yml
@@ -19,6 +19,31 @@
     - "Reconfigure Primary GitLab"
     - "Reconfigure Non Primary GitLab"
 
+- name: "Ensure gitaly['configuration'] is not present in gitlab_additional_configurations"
+  when: "gitlab_use_internal_gitaly"
+  block:
+    - name: "Check if gitaly is present"
+      when:
+        - "gitlab_additional_configurations | length > 0"
+        - "item.gitaly is defined"
+      ansible.builtin.set_fact:
+        __gitaly_item: "{{ item.gitaly }}"
+      with_items: "{{ gitlab_additional_configurations }}"
+
+    - name: "Check if gitaly['configuration'] is present"
+      when:
+        - "item.key is defined"
+        - "item.key == 'configuration'"
+      ansible.builtin.set_fact:
+        __gitaly_configuration_exists: true
+      with_items: "{{ __gitaly_item | default([]) }}"
+
+    - name: "Warn if gitaly['configuration'] is already present"
+      when:
+        - "__gitaly_configuration_exists"
+      ansible.builtin.debug:
+        msg: "Please make sure to configure gitaly storage paths yourself in gitaly['configuration']"
+
 - name: "Copy GitLab Configuration File."
   become: true
   ansible.builtin.template:

--- a/roles/gitlab/templates/gitlab.rb.j2
+++ b/roles/gitlab/templates/gitlab.rb.j2
@@ -31,6 +31,7 @@ gitlab_rails['redis_sentinels_password'] = "{{ gitlab_redis_sentinel_password }}
 gitlab_rails['monitoring_whitelist'] = ["{{ gitlab_ip_range }}"]
 
 {% if gitlab_use_internal_gitaly %}
+{% if not __gitaly_configuration_exists %}
 gitaly['configuration'] = {
   "storage": [
     {
@@ -39,6 +40,7 @@ gitaly['configuration'] = {
     },
   ],
 }
+{% endif %}
 {% else %}
 gitaly['enable'] = false
 gitlab_rails['gitaly_token'] = "{{ gitlab_gitaly_token }}"

--- a/roles/gitlab/templates/gitlab.rb.j2
+++ b/roles/gitlab/templates/gitlab.rb.j2
@@ -31,14 +31,23 @@ gitlab_rails['redis_sentinels_password'] = "{{ gitlab_redis_sentinel_password }}
 gitlab_rails['monitoring_whitelist'] = ["{{ gitlab_ip_range }}"]
 
 {% if gitlab_use_internal_gitaly %}
-git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })
+gitaly['configuration'] = {
+  "storage": [
+    {
+      "name": "default",
+      "path": "{{ (gitlab_git_data_dir, 'repositories') | path_join }}",
+    },
+  ],
+}
 {% else %}
 gitaly['enable'] = false
 gitlab_rails['gitaly_token'] = "{{ gitlab_gitaly_token }}"
 gitlab_shell['secret_token'] = "{{ gitlab_secret_token }}"
-git_data_dirs({
-  'default' => { 'gitaly_address' => 'tcp://{{ gitlab_gitaly_instance_ip }}:{{ gitlab_gitaly_instance_port }}' },
-})
+gitlab_rails['repositories_storages'] = {
+  "default" => {
+    "gitaly_address" => "tcp://{{ gitlab_gitaly_instance_ip }}:{{ gitlab_gitaly_instance_port }}"
+  }
+}
 {% endif %}
 
 gitlab_rails['gitlab_email_enabled'] = {{ gitlab_email_enabled }}


### PR DESCRIPTION
Starting with GitLab 18.0 git_data_dirs will be removed. They need to be replaced according to: https://docs.gitlab.com/omnibus/settings/configuration/#migrating-from-git_data_dirs

@Normo Do we want to provide a fallback for older GitLab versions? In principle the new method is now supported for quite a couple of releases.

Related to #366 