### PR TITLE
Do not pin GitLab in Molecule

### DIFF
--- a/molecule/gitlab/molecule.yml
+++ b/molecule/gitlab/molecule.yml
@@ -29,8 +29,6 @@ provisioner:
   inventory:
     host_vars:
       instancegitlab:
-        gitlab_version: "17.11.2"
-        gitlab_release: "ce.0"
         gitlab_edition: "gitlab-ce"
         gitlab_ip_range: "0.0.0.0/0"
         gitlab_additional_configurations:


### PR DESCRIPTION
Fixed with https://about.gitlab.com/releases/2025/05/21/patch-release-gitlab-18-0-1-released/.