### PR TITLE
Remove support for Ansible EOL 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We decided to reuse the unattended_upgrades repository as a collection repo as i
 
 ## Minimum required Ansible-version
 
-* Ansible >= 2.16
+* Ansible >= 2.17
 
 ## Installation
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-requires_ansible: '>=2.16.0'
+requires_ansible: '>=2.17.0'

--- a/roles/gitlab/meta/main.yml
+++ b/roles/gitlab/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
 
   license: "Apache-2.0"
 
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/gitlab_runner/meta/main.yml
+++ b/roles/gitlab_runner/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   company: "Helmholtz Association"
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
   license: "Apache-2.0"
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
 
   license: "Apache-2.0"
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/keepalived/meta/main.yml
+++ b/roles/keepalived/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
 
   license: "Apache-2.0"
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/netplan/meta/main.yml
+++ b/roles/netplan/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
   license: "Apache-2.0"
 
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/redis/meta/main.yml
+++ b/roles/redis/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
   license: "Apache-2.0"
 
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/ssh_keys/meta/main.yml
+++ b/roles/ssh_keys/meta/main.yml
@@ -13,7 +13,7 @@ galaxy_info:
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
 
   license: "Apache-2.0"
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "EL"

--- a/roles/unattended_upgrades/meta/main.yml
+++ b/roles/unattended_upgrades/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   author: "hifis"
   description: "Setup unattended-upgrades on Debian-based systems"
   license: "GPLv2"
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
   platforms:
     - name: "Ubuntu"
       versions:

--- a/roles/zammad/meta/main.yml
+++ b/roles/zammad/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   company: "Helmholtz Association of German Research Centres"
   license: "MIT"
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
-  min_ansible_version: "2.16"
+  min_ansible_version: "2.17"
 
   platforms:
     - name: "Ubuntu"


### PR DESCRIPTION
Ansible 2.16 support ends on 31 May 2025.