### PR TITLE
Allow users to overwrite gitlab_rails['repositories_storages']

### DIFF
--- a/roles/gitlab/README.md
+++ b/roles/gitlab/README.md
@@ -216,6 +216,16 @@ gitlab_feature_flags:
     enabled: false
 ```
 
+#### Configure gitlab_rails['repositories_storages'] on your own
+
+If you have the requirement to configure gitlab_rails['repositories_storages']
+on your own, set this variable to `false`.
+This can be useful if you want to configure multiple Gitaly instances.
+
+```yaml
+gitlab_use_default_repositories_storages: true
+```
+
 #### Mattermost only use case
 
 This role can be used to run Mattermost without deploying GitLab. In this

--- a/roles/gitlab/defaults/main.yml
+++ b/roles/gitlab/defaults/main.yml
@@ -64,6 +64,8 @@ gitlab_secret_token: "changeme"
 gitlab_gitaly_instance_ip: "127.0.0.1"
 # Port of the Gitaly instance
 gitlab_gitaly_instance_port: "8075"
+# Set to false to define gitlab_rails['repositories_storages'] on your own
+gitlab_use_default_repositories_storages: true
 
 # Whether to use GitLab Omnibus internal PostgreSQL database
 gitlab_use_internal_postgresql: "true"

--- a/roles/gitlab/templates/gitlab.rb.j2
+++ b/roles/gitlab/templates/gitlab.rb.j2
@@ -45,11 +45,13 @@ gitaly['configuration'] = {
 gitaly['enable'] = false
 gitlab_rails['gitaly_token'] = "{{ gitlab_gitaly_token }}"
 gitlab_shell['secret_token'] = "{{ gitlab_secret_token }}"
+{% if gitlab_use_default_repositories_storages %}
 gitlab_rails['repositories_storages'] = {
   "default" => {
     "gitaly_address" => "tcp://{{ gitlab_gitaly_instance_ip }}:{{ gitlab_gitaly_instance_port }}"
   }
 }
+{% endif %}
 {% endif %}
 
 gitlab_rails['gitlab_email_enabled'] = {{ gitlab_email_enabled }}


### PR DESCRIPTION
This is useful if users want to configure more than one instance of Gitaly or need to specify more options.