### PR TITLE
Replace hardcoded GPG key for Redhat

### DIFF
--- a/roles/gitlab/tasks/install.yml
+++ b/roles/gitlab/tasks/install.yml
@@ -70,7 +70,7 @@
         enabled: true
         gpgkey:
           - "{{ gitlab_gpg_key_url }}"
-          - "{{ gitlab_gpg_key_url }}/gitlab-{{ gitlab_edition }}-3D645A26AB9FBD22.pub.gpg"
+          - "{{ gitlab_gpg_key_url }}/gitlab-{{ gitlab_edition }}-{{ gitlab_gpg_key_id }}.pub.gpg"
         sslverify: true
         sslcacert: "/etc/pki/tls/certs/ca-bundle.crt"
         metadata_expire: "300"
@@ -86,7 +86,7 @@
         enabled: true
         gpgkey:
           - "{{ gitlab_gpg_key_url }}"
-          - "{{ gitlab_gpg_key_url }}/gitlab-{{ gitlab_edition }}-3D645A26AB9FBD22.pub.gpg"
+          - "{{ gitlab_gpg_key_url }}/gitlab-{{ gitlab_edition }}-{{ gitlab_gpg_key_id }}.pub.gpg"
         sslverify: true
         sslcacert: "/etc/pki/tls/certs/ca-bundle.crt"
         metadata_expire: "300"


### PR DESCRIPTION
We would like to customize the GPG key for Redhat installations of GitLab.
Currently, this is done for Debian installations but not for Redhat ones.
The idea is to reuse the variable gitlab_gpg_key_id (but it can be done with a new variable if it's more acceptable).