### PR TITLE
Make sure to run registry metadata database migrations

### DIFF
--- a/molecule/gitlab/molecule.yml
+++ b/molecule/gitlab/molecule.yml
@@ -40,6 +40,19 @@ provisioner:
               - key: "env"
                 type: "plain"
                 value: "{ 'OWN_PRIVATE_API_URL' => 'grpc://127.0.0.1:8155' }"
+          - registry:
+              - key: "database"
+                type: "plain"
+                value: |-
+                  {
+                    'enabled' => false,
+                    'host' => '{{ gitlab_postgresql_db_host }}',
+                    'port' => {{ gitlab_postgresql_db_port }},
+                    'user' => 'gitlab',
+                    'password' => '{{ gitlab_postgresql_db_password }}',
+                    'dbname' => 'registry',
+                    'sslmode' => 'disable'
+                  }
         gitlab_feature_flags:
           # See https://docs.gitlab.com/ee/user/feature_flags.html
           - name: "vscode_web_ide"

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -22,10 +22,8 @@
 
 - name: "Run registry metadata database migrations"
   become: true
-  ansible.builtin.command: "gitlab-ctl registry-database migrate up"
+  ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
   changed_when: true
-  environment:
-    SKIP_POST_DEPLOYMENT_MIGRATIONS: true
   when:
     - "__gitlab_registry_database_used"
     - "gitlab_is_primary"

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -20,6 +20,10 @@
   listen: "GitLab has been installed or upgraded"
   when: "gitlab_is_primary"
 
+- name: "Trigger registry metadata database migrations"
+  ansible.builtin.include_tasks: "registry_metadata_db.yml"
+  when: "gitlab_is_primary"
+
 - name: "Reconfigure Non Primary GitLab"
   become: true
   ansible.builtin.shell:

--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -20,9 +20,15 @@
   listen: "GitLab has been installed or upgraded"
   when: "gitlab_is_primary"
 
-- name: "Trigger registry metadata database migrations"
-  ansible.builtin.include_tasks: "registry_metadata_db.yml"
-  when: "gitlab_is_primary"
+- name: "Run registry metadata database migrations"
+  become: true
+  ansible.builtin.command: "gitlab-ctl registry-database migrate up"
+  changed_when: true
+  environment:
+    SKIP_POST_DEPLOYMENT_MIGRATIONS: true
+  when:
+    - "__gitlab_registry_database_used"
+    - "gitlab_is_primary"
 
 - name: "Reconfigure Non Primary GitLab"
   become: true

--- a/roles/gitlab/handlers/registry_metadata_db.yml
+++ b/roles/gitlab/handlers/registry_metadata_db.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+
+- name: "Check if registry configuration exists"
+  ansible.builtin.set_fact:
+    __gitlab_registry_config: "{{ item.registry }}"
+  when: "item.registry is defined"
+  loop: "{{ gitlab_additional_configurations }}"
+
+- name: "Check if database key is defined in registry"
+  ansible.builtin.set_fact:
+    __gitlab_registry_database_used: "{{ __gitlab_registry_config | default([]) | selectattr('key', '==', 'database') | list | length > 0 }}"
+
+- name: "Run registry metadata database migrations"
+  become: true
+  ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
+  changed_when: true
+  when:
+    - "__gitlab_registry_database_used"

--- a/roles/gitlab/tasks/check.yml
+++ b/roles/gitlab/tasks/check.yml
@@ -4,6 +4,20 @@
 
 ---
 
+- name: "Check whether gitlab-rails binary is installed"
+  ansible.builtin.stat:
+    path: "/usr/bin/gitlab-rails"
+  register: "gitlab_rails_binary"
+
+- name: "Determine if this is an initial dry-run"
+  ansible.builtin.set_fact:
+    gitlab_is_initial_dryrun: "{{ ansible_check_mode and not gitlab_rails_binary.stat.exists }}"
+
+- name: "Check if a previous reconfigure had failed"
+  ansible.builtin.stat:
+    path: "/etc/gitlab/reconfigure_failed"
+  register: "gitlab_reconfigure_failed"
+
 - name: "Check if registry configuration exists"
   ansible.builtin.set_fact:
     __gitlab_registry_config: "{{ item.registry }}"
@@ -13,10 +27,3 @@
 - name: "Check if database key is defined in registry"
   ansible.builtin.set_fact:
     __gitlab_registry_database_used: "{{ __gitlab_registry_config | default([]) | selectattr('key', '==', 'database') | list | length > 0 }}"
-
-- name: "Run registry metadata database migrations"
-  become: true
-  ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
-  changed_when: true
-  when:
-    - "__gitlab_registry_database_used"

--- a/roles/gitlab/tasks/configure.yml
+++ b/roles/gitlab/tasks/configure.yml
@@ -17,6 +17,7 @@
   no_log: "{{ gitlab_hide_sensitive_changes }}"
   notify:
     - "Reconfigure Primary GitLab"
+    - "Trigger registry metadata database migrations"
     - "Reconfigure Non Primary GitLab"
 
 - name: "Ensure gitaly['configuration'] is not present in gitlab_additional_configurations"
@@ -55,6 +56,7 @@
   no_log: "{{ gitlab_hide_sensitive_changes }}"
   notify:
     - "Reconfigure Primary GitLab"
+    - "Trigger registry metadata database migrations"
     - "Reconfigure Non Primary GitLab"
 
 - name: "Create file to prevent Gitlab to restart before migrations"

--- a/roles/gitlab/tasks/configure.yml
+++ b/roles/gitlab/tasks/configure.yml
@@ -17,7 +17,7 @@
   no_log: "{{ gitlab_hide_sensitive_changes }}"
   notify:
     - "Reconfigure Primary GitLab"
-    - "Trigger registry metadata database migrations"
+    - "Run registry metadata database migrations"
     - "Reconfigure Non Primary GitLab"
 
 - name: "Ensure gitaly['configuration'] is not present in gitlab_additional_configurations"
@@ -56,7 +56,7 @@
   no_log: "{{ gitlab_hide_sensitive_changes }}"
   notify:
     - "Reconfigure Primary GitLab"
-    - "Trigger registry metadata database migrations"
+    - "Run registry metadata database migrations"
     - "Reconfigure Non Primary GitLab"
 
 - name: "Create file to prevent Gitlab to restart before migrations"

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -8,19 +8,8 @@
 - name: "Set OS distribution dependent variables"
   ansible.builtin.include_vars: "{{ ansible_facts.distribution }}.yml"
 
-- name: "Check whether gitlab-rails binary is installed"
-  ansible.builtin.stat:
-    path: "/usr/bin/gitlab-rails"
-  register: "gitlab_rails_binary"
-
-- name: "Determine if this is an initial dry-run"
-  ansible.builtin.set_fact:
-    gitlab_is_initial_dryrun: "{{ ansible_check_mode and not gitlab_rails_binary.stat.exists }}"
-
-- name: "Check if a previous reconfigure had failed"
-  ansible.builtin.stat:
-    path: "/etc/gitlab/reconfigure_failed"
-  register: "gitlab_reconfigure_failed"
+- name: "Perform prerequisite checks"
+  ansible.builtin.import_tasks: "check.yml"
 
 - name: "Reconfigure GitLab"
   ansible.builtin.import_tasks: "reconfigure.yml"

--- a/roles/gitlab/tasks/reconfigure.yml
+++ b/roles/gitlab/tasks/reconfigure.yml
@@ -21,25 +21,13 @@
   when:
     - "not gitlab_is_primary"
 
-- name: "Trigger registry metadata database migrations"
-  when: "gitlab_is_primary"
-  block:
-    - name: "Check if registry configuration exists"
-      ansible.builtin.set_fact:
-        __gitlab_registry_config: "{{ item.registry }}"
-      when: "item.registry is defined"
-      loop: "{{ gitlab_additional_configurations }}"
-
-    - name: "Check if database key is defined in registry"
-      ansible.builtin.set_fact:
-        __gitlab_registry_database_used: "{{ __gitlab_registry_config | default([]) | selectattr('key', '==', 'database') | list | length > 0 }}"
-
-    - name: "Run registry metadata database migrations"
-      become: true
-      ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
-      changed_when: true
-      when:
-        - "__gitlab_registry_database_used"
+- name: "Run registry metadata database migrations"
+  become: true
+  ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
+  changed_when: true
+  when:
+    - "__gitlab_registry_database_used"
+    - "gitlab_is_primary"
 
 - name: "Remove file that indicates a failed reconfigure"
   ansible.builtin.file:

--- a/roles/gitlab/tasks/reconfigure.yml
+++ b/roles/gitlab/tasks/reconfigure.yml
@@ -21,6 +21,26 @@
   when:
     - "not gitlab_is_primary"
 
+- name: "Trigger registry metadata database migrations"
+  when: "gitlab_is_primary"
+  block:
+    - name: "Check if registry configuration exists"
+      ansible.builtin.set_fact:
+        __gitlab_registry_config: "{{ item.registry }}"
+      when: "item.registry is defined"
+      loop: "{{ gitlab_additional_configurations }}"
+
+    - name: "Check if database key is defined in registry"
+      ansible.builtin.set_fact:
+        __gitlab_registry_database_used: "{{ __gitlab_registry_config | default([]) | selectattr('key', '==', 'database') | list | length > 0 }}"
+
+    - name: "Run registry metadata database migrations"
+      become: true
+      ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
+      changed_when: true
+      when:
+        - "__gitlab_registry_database_used"
+
 - name: "Remove file that indicates a failed reconfigure"
   ansible.builtin.file:
     path: "/etc/gitlab/reconfigure_failed"


### PR DESCRIPTION
So far, registry database migrations have not automatically triggered. This change checks if the registry metadata database is configured. If the database is configured, it ensures that database migrations are triggered.

See also https://docs.gitlab.com/administration/packages/container_registry_metadata_database/#database-migrations