### PR TITLE
Ensure stable order in gitlab_rails monitoring_whitelist

### DIFF
--- a/roles/gitlab/templates/gitlab.rb.j2
+++ b/roles/gitlab/templates/gitlab.rb.j2
@@ -28,7 +28,7 @@ gitlab_rails['redis_sentinels'] = [
 gitlab_rails['redis_sentinels_password'] = "{{ gitlab_redis_sentinel_password }}"
 {% endif %}
 {% endif %}
-gitlab_rails['monitoring_whitelist'] = [{{ gitlab_rails_monitoring_whitelist | map('to_json') | join(', ') }}]
+gitlab_rails['monitoring_whitelist'] = [{{ (gitlab_rails_monitoring_whitelist | list | unique | sort) | map('to_json') | join(', ') }}]
 
 {% if gitlab_use_internal_gitaly %}
 {% if not __gitaly_configuration_exists %}


### PR DESCRIPTION
The `gitlab_rails['monitoring_whitelist']` rendering used a raw list, which does not guarantee element order. This caused non-idempotent behavior and unnecessary diffs between runs.

The template now applies `unique | sort` before rendering, ensuring stable and idempotent configuration output.