### PR TITLE
gitlab_runner: fix user_data template double JSON encoding

### DIFF
--- a/molecule/gitlab_runner/molecule.yml
+++ b/molecule/gitlab_runner/molecule.yml
@@ -27,6 +27,8 @@ platforms:
     tty: true
 provisioner:
   name: "ansible"
+  options:
+    D: true
   playbooks:
     prepare: "prepare.yml"
     converge: "converge.yml"
@@ -35,6 +37,7 @@ provisioner:
       all:
         vars:
           gitlab_runner_concurrent: 4
+          gitlab_runner_hide_sensitive_changes: false
     host_vars:
       instancegitlabciopenstack1:
         gitlab_runner_version: "18.0.2"

--- a/roles/gitlab_runner/templates/config.toml.j2
+++ b/roles/gitlab_runner/templates/config.toml.j2
@@ -114,7 +114,7 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
     networks = [ { uuid = "{{ runner.autoscaler_network_id }}" } ]
     security_groups = [ "{{ runner.autoscaler_security_group }}" ]
     scheduler_hints = { group = "{{ runner.autoscaler_scheduler_hint }}" }
-    user_data = '{{ __ignition_content | to_json }}'
+    user_data = '''{{ __ignition_content | trim }}'''
 
   [runners.autoscaler.connector_config]
     username = "{{ runner.autoscaler_username }}"


### PR DESCRIPTION
- Remove `to_json` filter
- Use TOML literal multiline string (`'''...'''`)
- Removes any spaces, tabs, or line breaks with `| trim`


* Closes #493 