### PR TITLE
Allow configurable NGINX locations for serving static files

### DIFF
--- a/molecule/zammad/molecule.yml
+++ b/molecule/zammad/molecule.yml
@@ -31,5 +31,10 @@ provisioner:
       all:
         vars:
           ansible_user: "ansible"
+          zammad_nginx_additional_locations:
+            - |
+              location ~* \\.html$$ {
+                access_log off; log_not_found off;
+              }
 verifier:
   name: "ansible"

--- a/roles/zammad/README.md
+++ b/roles/zammad/README.md
@@ -118,6 +118,17 @@ configuring multiple domains or the redirection of outdated domains to the
 most recent one.
 
 ```yaml
+zammad_nginx_additional_locations:
+  - |
+    location ~* \.html$ {
+      root /opt/zammad/public;
+    }
+```
+
+Configure additional location directives in the Nginx server configuration.
+This allows to serve additional files from the public directory, e.g. custom HTML files.
+
+```yaml
 zammad_elasticsearch_url: "http://localhost:9200"
 ```
 

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -15,6 +15,7 @@ zammad_ssl_key_path: "/etc/ssl/private/zammad_key.pem"
 
 zammad_nginx_additional_server_configs: []
 zammad_nginx_server_tokens: "off"
+zammad_nginx_additional_locations: []
 
 zammad_force_es_searchindex_rebuild: false
 

--- a/roles/zammad/templates/nginx-zammad.conf.j2
+++ b/roles/zammad/templates/nginx-zammad.conf.j2
@@ -46,6 +46,10 @@ server {
         access_log off; log_not_found off;
     }
 
+    {% for location_config in zammad_nginx_additional_locations %}
+    {{ location_config }}
+    {% endfor %}
+
     root /opt/zammad/public;
 
     access_log /var/log/nginx/zammad.access.log;


### PR DESCRIPTION
Add support for custom location blocks in Zammad's NGINX configuration to serve additional files from the public directory.