### PR TITLE
Bump default Zammad version to 7.0.1

### DIFF
--- a/roles/zammad/README.md
+++ b/roles/zammad/README.md
@@ -30,7 +30,7 @@ The below requirements are needed on the target host:
 ## Role Variables
 
 ```yaml
-zammad_version: "6.5.0"
+zammad_version: "7.0.1"
 ```
 
 Zammad version to be installed.

--- a/roles/zammad/defaults/main.yml
+++ b/roles/zammad/defaults/main.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 ---
-zammad_version: "6.5.0"
+zammad_version: "7.0.1"
 zammad_release_channel: "stable"
 zammad_repo_url: "https://dl.packager.io/srv/deb/zammad/zammad/{{ zammad_release_channel }}/{{ ansible_facts.distribution | lower }}"
 zammad_domain_name: "{{ ansible_facts.fqdn }}"

--- a/roles/zammad/templates/nginx-zammad.conf.j2
+++ b/roles/zammad/templates/nginx-zammad.conf.j2
@@ -84,6 +84,9 @@ server {
     {% endif %}
 
     location / {
+        {% if zammad_version is version('7.0', 'ge') +%}
+        proxy_http_version 1.1;
+        {% endif %}
         proxy_set_header Host $http_host;
         proxy_set_header CLIENT_IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Configure proxy_http_version in nginx config.
This is required as of Zammad 7 as described in https://github.com/zammad/zammad/blob/7.0.0/BREAKING_CHANGES.md#nginx-configuration-update