### PR TITLE
Configure ANSIBLE_ROLES_PATH for scenarios pulling Galaxy roles

### DIFF
--- a/molecule/gitlab_runner/molecule.yml
+++ b/molecule/gitlab_runner/molecule.yml
@@ -27,6 +27,8 @@ platforms:
     tty: true
 provisioner:
   name: "ansible"
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/roles"
   options:
     diff: true
   playbooks:

--- a/molecule/zammad/molecule.yml
+++ b/molecule/zammad/molecule.yml
@@ -23,6 +23,8 @@ platforms:
       - "0.0.0.0:8443:443"
 provisioner:
   name: "ansible"
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/roles"
   playbooks:
     prepare: "prepare.yml"
     converge: "converge.yml"


### PR DESCRIPTION
The _gitlab_runner_ and _zammad_ scenarios depend on external Galaxy roles that the molecule dependency step installs into the collection's roles/ directory. Without an explicit roles path, Ansible looks for them only in the scenario directory and `~/.ansible/roles`, which fails locally unless a symlink is created manually.

Point `ANSIBLE_ROLES_PATH` at the project's roles/ directory so the roles are discovered out of the box. The existing workaround used by the CI workflows continues to work and stays untouched.