### PR TITLE
Declare external collection dependencies in galaxy.yml

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/gitlab/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/gitlab/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: "0 0 * * *"
 env:

--- a/.github/workflows/gitlab_runner.yml
+++ b/.github/workflows/gitlab_runner.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/gitlab_runner/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/gitlab_runner/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: "0 0 * * *"
 env:

--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/haproxy/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/haproxy/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/keepalived.yml
+++ b/.github/workflows/keepalived.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/keepalived/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/keepalived/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/netplan.yml
+++ b/.github/workflows/netplan.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/netplan/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/netplan/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/redis/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/redis/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: "0 0 * * *"
 env:

--- a/.github/workflows/ssh_keys.yml
+++ b/.github/workflows/ssh_keys.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/ssh_keys/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/ssh_keys/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/unattended_upgrades.yml
+++ b/.github/workflows/unattended_upgrades.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/unattended_upgrades/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/unattended_upgrades/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/zammad.yml
+++ b/.github/workflows/zammad.yml
@@ -15,6 +15,7 @@ on:
       - 'molecule/zammad/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   push:
     branches:
       - "main"
@@ -27,6 +28,7 @@ on:
       - 'molecule/zammad/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      - 'galaxy.yml'
   schedule:
     - cron: '0 0 * * *'
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,7 +20,10 @@ tags:
   - 'debian'
   - 'linux'
   - 'system'
-dependencies: {}
+dependencies:
+  ansible.posix: '>=2.1.0'
+  community.crypto: '>=3.0.0'
+  community.general: '>=11.0.0'
 repository: 'https://github.com/hifis-net/ansible-collection-toolkit'
 homepage: 'https://hifis.net/services/software-overview.html'
 issues: 'https://github.com/hifis-net/ansible-collection-toolkit/issues'

--- a/molecule/zammad/requirements.yml
+++ b/molecule/zammad/requirements.yml
@@ -7,7 +7,6 @@
 
 collections:
   - name: "community.crypto"
-    version: "2.20.0"
 
 roles:
   - src: "geerlingguy.elasticsearch"


### PR DESCRIPTION
The collection uses modules from `ansible.posix`, `community.crypto` and `community.general` but did not declare them as dependencies, so consumers installing `hifis.toolkit` via `ansible-galaxy` did not get them automatically and hit runtime errors on ansible-core-only setups.

The minimum versions are aligned with the collection versions shipped in the Ansible 12 community package, the first one based on ansible-core 2.19, which is the oldest ansible-core release that is not end of life. All three minimum versions still support ansible-core 2.17, so this does not affect the requires_ansible constraint of this collection.

Fixes #589