### PR TITLE
Require ansible-core 2.19 as minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We decided to reuse the unattended_upgrades repository as a collection repo as i
 
 ## Minimum required Ansible-version
 
-* Ansible >= 2.17
+* Ansible >= 2.19
 
 ## Installation
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-requires_ansible: '>=2.17.0'
+requires_ansible: '>=2.19.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "This collection provides production-ready Ansible roles used for 
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "ansible>=11.9.0",
+    "ansible>=12.0.0",
 ]
 
 [dependency-groups]

--- a/roles/gitlab/meta/main.yml
+++ b/roles/gitlab/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
 
   license: "Apache-2.0"
 
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/gitlab_runner/meta/main.yml
+++ b/roles/gitlab_runner/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   company: "Helmholtz Association"
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
   license: "Apache-2.0"
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
 
   license: "Apache-2.0"
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/keepalived/meta/main.yml
+++ b/roles/keepalived/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
 
   license: "Apache-2.0"
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/netplan/meta/main.yml
+++ b/roles/netplan/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
   license: "Apache-2.0"
 
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/redis/meta/main.yml
+++ b/roles/redis/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
   license: "Apache-2.0"
 
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "Ubuntu"

--- a/roles/ssh_keys/meta/main.yml
+++ b/roles/ssh_keys/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
 
   license: "Apache-2.0"
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "EL"

--- a/roles/unattended_upgrades/meta/main.yml
+++ b/roles/unattended_upgrades/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   author: "hifis"
   description: "Setup unattended-upgrades on Debian-based systems"
   license: "GPLv2"
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
   platforms:
     - name: "Ubuntu"
       versions:

--- a/roles/zammad/meta/main.yml
+++ b/roles/zammad/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   company: "Helmholtz Association of German Research Centres"
   license: "MIT"
   issue_tracker_url: "https://github.com/hifis-net/ansible-collection-toolkit/issues"
-  min_ansible_version: "2.17"
+  min_ansible_version: "2.19"
 
   platforms:
     - name: "Ubuntu"

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "ansible", specifier = ">=11.9.0" }]
+requires-dist = [{ name = "ansible", specifier = ">=12.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Raise the minimum supported Ansible version from ansible-core 2.17 to 2.19. Both ansible-core 2.17 and 2.18 are end of life and no longer receive security fixes; 2.19 is the oldest still maintained release.

Update requires_ansible in meta/runtime.yml, min_ansible_version in all role metadata, the README, and bump the ansible Python package to >=12.0.0 (the first release based on ansible-core 2.19) in pyproject.toml along with the uv lock file.