### PR TITLE
Add support for Ubuntu 26.04 in haproxy role

### DIFF
--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -46,6 +46,7 @@ jobs:
         image:
           - "ghcr.io/hifis-net/ubuntu-systemd:22.04"
           - "ghcr.io/hifis-net/ubuntu-systemd:24.04"
+          - "ghcr.io/hifis-net/ubuntu-systemd:26.04"
           - "ghcr.io/hifis-net/debian-systemd:11"
           - "ghcr.io/hifis-net/debian-systemd:12"
 

--- a/molecule/haproxy/molecule.yml
+++ b/molecule/haproxy/molecule.yml
@@ -9,6 +9,13 @@ dependency:
 driver:
   name: "podman"
 platforms:
+  - name: "haproxy_v3.4"
+    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
+    pre_build_image: true
+    privileged: true
+    override_command: false
+    systemd: true
+    tty: true
   - name: "haproxy_v3.2"
     image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
     pre_build_image: true
@@ -37,13 +44,6 @@ platforms:
     override_command: false
     systemd: "true"
     tty: true
-  - name: "haproxy_v2.4"
-    image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"
-    pre_build_image: true
-    privileged: true
-    override_command: false
-    systemd: "true"
-    tty: true
 provisioner:
   name: "ansible"
   inventory:
@@ -52,6 +52,10 @@ provisioner:
         vars:
           haproxy_ssl_dhparam_size: 512
     host_vars:
+      haproxy_v3.4:
+        haproxy_create_self_signed_cert: true
+        haproxy_ppa_version: "ppa:vbernat/haproxy-3.4"
+        haproxy_version: "3.4.*"
       haproxy_v3.2:
         haproxy_create_self_signed_cert: true
         haproxy_ppa_version: "ppa:vbernat/haproxy-3.2"
@@ -69,10 +73,6 @@ provisioner:
         haproxy_ssl_cert_chain_src_file_path: "{{ (lookup('env', 'MOLECULE_SCENARIO_DIRECTORY'), 'test.pem') | path_join }}"
         haproxy_ppa_version: "ppa:vbernat/haproxy-2.6"
         haproxy_version: "2.6.*"
-      haproxy_v2.4:
-        haproxy_create_self_signed_cert: true
-        haproxy_ppa_version: "ppa:vbernat/haproxy-2.4"
-        haproxy_version: "2.4.*"
   playbooks:
     prepare: "prepare.yml"
     check: "converge.yml"

--- a/molecule/haproxy/molecule.yml
+++ b/molecule/haproxy/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     pre_build_image: true
     privileged: true
     override_command: false
-    systemd: true
+    systemd: "true"
     tty: true
   - name: "haproxy_v3.2"
     image: "${MOLECULE_IMAGE:-ghcr.io/hifis-net/ubuntu-systemd:24.04}"

--- a/molecule/haproxy/prepare.yml
+++ b/molecule/haproxy/prepare.yml
@@ -12,7 +12,7 @@
         name:
           - "sudo"                        # for `become` privilege escalation
           - "iproute2"                    # for gathering network facts
-          - "gnupg2"                      # for use with "apt-key export"
+          - "gnupg2"                      # for use with GPG key operations
           - "software-properties-common"  # for use with "apt-repository"
           - "python3-debian"
           - "python3-cryptography"        # for use with openssl modules

--- a/molecule/haproxy/verify.yml
+++ b/molecule/haproxy/verify.yml
@@ -18,7 +18,9 @@
       ansible.builtin.meta: "end_host"
       when: >-
         ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.9', '<') or
-        ansible_facts.distribution_release | lower != 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=')
+        ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.4', '>=') or
+        ansible_facts.distribution_release | lower == 'resolute' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '<') or
+        ansible_facts.distribution_release | lower not in ['noble', 'resolute'] and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=')
 
     - name: "Populate service facts."
       ansible.builtin.service_facts:

--- a/roles/haproxy/README.md
+++ b/roles/haproxy/README.md
@@ -14,6 +14,7 @@ and scalability context.
 
 Currently [supported platforms](meta/main.yml) are:
 
+- Ubuntu 26.04 LTS
 - Ubuntu 24.04 LTS
 - Ubuntu 22.04 LTS
 - Debian 11 (Bullseye)
@@ -23,10 +24,9 @@ This role is tested against the four latest LTS versions of HAProxy.
 Currently, this results in official support for the HAProxy release series:
 
 - `3.2` (not supported on Debian 11 and Ubuntu 22.04)
-- `3.0`
-- `2.8` (not supported on Ubuntu 24.04)
-- `2.6` (not supported on Ubuntu 24.04)
-- `2.4` (not supported on Debian 12 and Ubuntu 24.04)
+- `3.0` (not supported on Ubuntu 26.04)
+- `2.8` (not supported on Ubuntu 24.04 and Ubuntu 26.04)
+- `2.6` (not supported on Ubuntu 24.04 and Ubuntu 26.04)
 
 Other versions are known to work as well but are not automatically tested.
 

--- a/roles/haproxy/README.md
+++ b/roles/haproxy/README.md
@@ -20,13 +20,16 @@ Currently [supported platforms](meta/main.yml) are:
 - Debian 11 (Bullseye)
 - Debian 12 (Bookworm)
 
-This role is tested against the four latest LTS versions of HAProxy.
+This role is tested against the maintained LTS versions of HAProxy.
 Currently, this results in official support for the HAProxy release series:
 
-- `3.2` (not supported on Debian 11 and Ubuntu 22.04)
-- `3.0` (not supported on Ubuntu 26.04)
-- `2.8` (not supported on Ubuntu 24.04 and Ubuntu 26.04)
-- `2.6` (not supported on Ubuntu 24.04 and Ubuntu 26.04)
+| HAProxy | Ubuntu 22.04 | Ubuntu 24.04 | Ubuntu 26.04 | Debian 11 | Debian 12 |
+|---------|:------------:|:------------:|:------------:|:---------:|:---------:|
+| `3.4`   | ❌ | ❌ | ✅ | ❌ | ❌ |
+| `3.2`   | ❌ | ✅ | ✅ | ❌ | ❌ |
+| `3.0`   | ✅ | ✅ | ❌ | ✅ | ✅ |
+| `2.8`   | ✅ | ❌ | ❌ | ✅ | ✅ |
+| `2.6`   | ✅ | ❌ | ❌ | ✅ | ✅ |
 
 Other versions are known to work as well but are not automatically tested.
 

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
       versions:
         - "jammy"
         - "noble"
+        - "resolute"
     - name: "Debian"
       versions:
         - "bullseye"

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -73,11 +73,44 @@
     - "ansible_facts.distribution == 'Ubuntu'"
     - "haproxy_ppa_version | length > 0"
   become: true
-  ansible.builtin.apt_repository:
-    repo: "{{ haproxy_ppa_version }}"
+  ansible.builtin.deb822_repository:
+    name: "haproxy-ppa"
+    types: "deb"
+    uris: "https://ppa.launchpadcontent.net/{{ haproxy_ppa_version | regex_replace('^ppa:', '') }}/ubuntu"
+    suites: "{{ ansible_facts.distribution_release | lower }}"
+    components: "main"
+    signed_by: |-
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+      xsFNBGY0i6UBEAC8tncBBAT1d2voTJRYwoUTxQcdcjG8ZRcKoKh0VFjYnHvhjdGr
+      +8TVSdIKhROz17kyIE6VxRw/jpyysn6FUT524uhm0SejdKxFadoUYyR0Eyb2MSbN
+      C3AaVYz1XGvwpri2Zr0E3HTlXP3P8TkPT3FBwBcMdlBbzDtDs4asWFl7VaS3tciy
+      FJGYCNYDVM69fIqQZnwDq5sJIl7X1kLDNnBxtHwp0TqJcBBSbqz7lqqo4zatQyl6
+      QcdwMSYCRi3QMr7EYmpqR6a7loWmr9W+YHFpfAmFt5QBldDdRZtJYzsT6IqQV8ZZ
+      iFQzUVa3VXGl24dY6YlaVSlsgCm+33vQgOd+m+nyWwGZQUUvBF2D3aG26XRjx7SC
+      R+DhYkQxVxhwiOoDUf0glBowWx6H5nNkJlNdidmQ9Z35PNtM6P42SHPLbfFESXGV
+      crmoCBXH3WE+0KEA3e+ER/o2Vny6l+I4SygVh7tG4BlNWeQmyYHPkrJD2HFNe98F
+      sNmJxhRjCJCKLQ8mKMRy0POSTt6JOybicrj0KhCiY+QpntAQjzAVmrD5ABSJsPqE
+      Btylv62Csn5Yw974rWoxKbY28Dg7rJ/vSinQOuiDbvigXw4kWNHw6f2T2pL9WAPZ
+      aovAf5W3juvUpg02JVoa9fKySfsnEKQE7TyEwweZXSLifmDSAx8N4W7ahwARAQAB
+      zSBMYXVuY2hwYWQgUFBBIGZvciBWaW5jZW50IEJlcm5hdMLBjgQTAQoAOBYhBD1l
+      OXD7qwqJDk5Omg8U2LDPTv6WBQJmNIulAhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4B
+      AheAAAoJEA8U2LDPTv6WBKgQALCcSVrRZAH6GZlwkZ0tBrv0YCL6bCMNOyIr5TaZ
+      lC2eRTYV/mPeTyc0aEBJKQ+uFT0Eiwi4fob8vaFXuvESzx1BJjLBquU5zuBy0l+Q
+      7+nui4y68ZxWm27cY7JWlzEkyvlADuNJoc3P0JsjZ0A/n04kXxw2gcGdriALU/Yy
+      o9WsW8OW+p39JUoVuZp247t3xazvbJyYvOXeSGsRQJPQlYfMuHqjI85Swsd2IHmO
+      XVV4Y19rRo4G+lD/n4f0QBguEPHbZG0zZRwQRWWHFiXjxvdjhHTzv9A7WMasEiCn
+      zszGAlYzJH3AoGUjjptxWTidjs67Am/4H0CpsXqi7uqPR3v3zJV5dZsL3kVIhR2W
+      wXYtrJ0T5lEKLvLlRNG6Hrw0DRUSGlTt6zHxZJOuBGbexs2O5RZER2JazjPWS48P
+      9ifu5xK2TECpT/Avz9j9u9svcunxLXGjfnUBCb580WXj6fULVYiJp7eWDwHlLAgX
+      pVZ4AKWO0khSjpvWUuuvWfTps9z013LyCAPwt/0GPOeN80pNpvRj6o23kssNvgf/
+      0Ak+H2HEkeixh9/lekDnUxbfujUCUC+dtjHzOZS+WNzeSDvBMrId9N5OxLY+CFNP
+      vd53n8/Ni8jq53Ide1+ZzN0uOmkWr7gznEsQDgsWsIE/oPgtcvqVrkyDyMjlSt7Y
+      fcbl
+      =3O9f
+      -----END PGP PUBLIC KEY BLOCK-----
     state: "present"
-    validate_certs: true
-    mode: "0644"
+    enabled: true
   register: "__ppa"
 
 - name: "Check whether wildcard character is contained in version string."

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -25,7 +25,9 @@
   ansible.builtin.meta: "end_host"
   when: >-
     ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.9', '<') or
-    ansible_facts.distribution_release | lower != 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=')
+    ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.4', '>=') or
+    ansible_facts.distribution_release | lower == 'resolute' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '<') or
+    ansible_facts.distribution_release | lower not in ['noble', 'resolute'] and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=')
 
 - name: "Enable ip_forward."
   become: true


### PR DESCRIPTION
Also remove testing for unsupported haproxy 2.4 release series

Related to #601 