### PR TITLE
Enable HAProxy 3.2 on Debian 12 (Bookworm)

### DIFF
--- a/molecule/haproxy/verify.yml
+++ b/molecule/haproxy/verify.yml
@@ -10,17 +10,20 @@
     - name: "Stop play for unsupported HAProxy / Debian combinations"
       ansible.builtin.meta: "end_host"
       when: >-
-        ansible_facts.distribution_release | lower == 'bookworm' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.4', '==') or
+        ansible_facts.distribution == 'Debian' and
+        (ansible_facts.distribution_release | lower == 'bookworm' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.4', '==') or
+        ansible_facts.distribution_release | lower == 'bookworm' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.4', '>=') or
         ansible_facts.distribution_release | lower == 'bullseye' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=') or
-        ansible_facts.distribution_release | lower == 'buster' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.8', '>=')
+        ansible_facts.distribution_release | lower == 'buster' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.8', '>='))
 
     - name: "Stop play for unsupported HAProxy / Ubuntu combinations"
       ansible.builtin.meta: "end_host"
       when: >-
-        ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.9', '<') or
+        ansible_facts.distribution == 'Ubuntu' and
+        (ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.9', '<') or
         ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.4', '>=') or
         ansible_facts.distribution_release | lower == 'resolute' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '<') or
-        ansible_facts.distribution_release | lower not in ['noble', 'resolute'] and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=')
+        ansible_facts.distribution_release | lower not in ['noble', 'resolute'] and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>='))
 
     - name: "Populate service facts."
       ansible.builtin.service_facts:

--- a/roles/haproxy/README.md
+++ b/roles/haproxy/README.md
@@ -25,11 +25,11 @@ Currently, this results in official support for the HAProxy release series:
 
 | HAProxy | Ubuntu 22.04 | Ubuntu 24.04 | Ubuntu 26.04 | Debian 11 | Debian 12 |
 |---------|:------------:|:------------:|:------------:|:---------:|:---------:|
-| `3.4`   | ❌ | ❌ | ✅ | ❌ | ❌ |
-| `3.2`   | ❌ | ✅ | ✅ | ❌ | ❌ |
-| `3.0`   | ✅ | ✅ | ❌ | ✅ | ✅ |
-| `2.8`   | ✅ | ❌ | ❌ | ✅ | ✅ |
-| `2.6`   | ✅ | ❌ | ❌ | ✅ | ✅ |
+| `3.4` | ❌ | ❌ | ✅ | ❌ | ❌ |
+| `3.2` | ❌ | ✅ | ✅ | ❌ | ✅ |
+| `3.0` | ✅ | ✅ | ❌ | ✅ | ✅ |
+| `2.8` | ✅ | ❌ | ❌ | ✅ | ✅ |
+| `2.6` | ✅ | ❌ | ❌ | ✅ | ✅ |
 
 Other versions are known to work as well but are not automatically tested.
 

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -17,17 +17,20 @@
 - name: "Stop role for unsupported HAProxy / Debian combinations"
   ansible.builtin.meta: "end_host"
   when: >-
-    ansible_facts.distribution_release | lower == 'bookworm' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.4', '==') or
+    ansible_facts.distribution == 'Debian' and
+    (ansible_facts.distribution_release | lower == 'bookworm' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.4', '==') or
+    ansible_facts.distribution_release | lower == 'bookworm' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.4', '>=') or
     ansible_facts.distribution_release | lower == 'bullseye' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=') or
-    ansible_facts.distribution_release | lower == 'buster' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.8', '>=')
+    ansible_facts.distribution_release | lower == 'buster' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.8', '>='))
 
 - name: "Stop role for unsupported HAProxy / Ubuntu combinations"
   ansible.builtin.meta: "end_host"
   when: >-
-    ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.9', '<') or
+    ansible_facts.distribution == 'Ubuntu' and
+    (ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('2.9', '<') or
     ansible_facts.distribution_release | lower == 'noble' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.4', '>=') or
     ansible_facts.distribution_release | lower == 'resolute' and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '<') or
-    ansible_facts.distribution_release | lower not in ['noble', 'resolute'] and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>=')
+    ansible_facts.distribution_release | lower not in ['noble', 'resolute'] and haproxy_version | regex_search('\\d+\\.\\d+') is version('3.2', '>='))
 
 - name: "Enable ip_forward."
   become: true


### PR DESCRIPTION
The cause was the fallback clause in the Ubuntu check, which matched any release not named _noble_ or _resolute_ and therefore also caught bookworm. Add checks on ansible_facts.distribution so that each one only ever evaluates releases of its own distribution, and add an explicit Debian clause that keeps blocking 3.4, which is not published for bookworm.