### PR TITLE
Enable ansible-lint rule role-argument-spec

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,3 +8,5 @@ exclude_paths:
   - ".ansible/"
 skip_list:
   - 'var-naming[no-role-prefix]'
+enable_list:
+  - 'role-argument-spec'


### PR DESCRIPTION
The rule is opt-in and therefore not active by default. Enabling it ensures every role of this collection ships a meta/argument_specs.yml.