### PR TITLE
gitlab-runner: Simplify installation and drop support for versions < 17.7.0

### DIFF
--- a/roles/gitlab_runner/defaults/main.yml
+++ b/roles/gitlab_runner/defaults/main.yml
@@ -6,7 +6,7 @@
 ---
 gitlab_runner_version: ""
 
-gitlab_runner_pkg_version: "{{ gitlab_runner_version + '-1' if gitlab_runner_version | length > 0 and gitlab_runner_version is version('16.9.0', 'ge') else gitlab_runner_version }}"
+gitlab_runner_pkg_version: "{{ gitlab_runner_version + '-1' if gitlab_runner_version | length > 0 else gitlab_runner_version }}"
 
 gitlab_runner_deb_file: ""
 

--- a/roles/gitlab_runner/tasks/install.debianlike.yml
+++ b/roles/gitlab_runner/tasks/install.debianlike.yml
@@ -69,7 +69,6 @@
       ansible.builtin.apt:
         deb: "{{ gitlab_runner_helper_images_deb_file }}"
         allow_downgrade: true
-      when: "gitlab_runner_version | length == 0 or gitlab_runner_version is version('17.7.0', 'ge')"
 
     - name: "Install gitlab-runner from a .deb file"
       become: true

--- a/roles/gitlab_runner/tasks/install.debianlike.yml
+++ b/roles/gitlab_runner/tasks/install.debianlike.yml
@@ -42,21 +42,12 @@
         mode: '0644'
       when: "ansible_facts.distribution == 'Debian'"
 
-    - name: "Install gitlab-runner-helper-images with downgrade option"
-      become: true
-      ansible.builtin.apt:
-        name: "{{ gitlab_runner_helper_images_package_name }}"
-        state: "present"
-        update_cache: true
-        allow_downgrade: true
-      when:
-        - "not __gitlab_runner_is_initial_dryrun"  # skip if run for the first time in check mode
-        - "gitlab_runner_version | length == 0 or gitlab_runner_version is version('17.7.0', 'ge')"
-
     - name: "Install gitlab-runner with downgrade option"
       become: true
       ansible.builtin.apt:
-        name: "{{ gitlab_runner_package_name }}"
+        name:
+          - "{{ gitlab_runner_package_name }}"
+          - "{{ gitlab_runner_helper_images_package_name }}"
         state: "present"
         update_cache: true
         allow_downgrade: true

--- a/roles/gitlab_runner/templates/pin-gitlab-runner.pref.j2
+++ b/roles/gitlab_runner/templates/pin-gitlab-runner.pref.j2
@@ -5,6 +5,6 @@ SPDX-FileCopyrightText: Helmholtz-Zentrum Dresden - Rossendorf (HZDR)
 SPDX-License-Identifier: Apache-2.0
 #}
 Explanation: Prefer GitLab provided packages over the Debian native ones
-Package: gitlab-runner
+Package: gitlab-runner gitlab-runner-helper-images
 Pin: origin packages.gitlab.com{% if gitlab_runner_version | length > 0 %}, version {{ gitlab_runner_pkg_version }}{% endif +%}
 Pin-Priority: 1001


### PR DESCRIPTION
This PR removes the version-dependent branches and simplifies the Debian-like installation path.

* Extend APT pinning to `gitlab-runner-helper-images`
* Install required packages in a single task
* Remove support for versions < 17.7.0

**Note:** CI for Debian 11 Bullseye fails because it reached EOL (see #626)